### PR TITLE
Added a very basic nix flake

### DIFF
--- a/README.org
+++ b/README.org
@@ -19,3 +19,9 @@ You can download a prebuild version from [[https://j-keck.github.io/zsd/docs/ins
 #+BEGIN_SRC sh
 ./zsd <FILE> <ACTION>
 #+END_SRC
+
+*** Nix flakes
+
+#+BEGIN_SRC sh
+nix run github:j-keck/zsd
+#+END_SRC

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678594102,
+        "narHash": "sha256-OHAHYiMWJFPNxuW/PcOMlSD2tvXnEYC1jxREBADHwwQ=",
+        "owner": "Nixos",
+        "repo": "nixpkgs",
+        "rev": "796b4a3c1d903c4b9270cd2548fe46f524eeb886",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,67 @@
+{
+  description = "A simple Go package";
+
+  # Nixpkgs / NixOS version to use.
+  inputs.nixpkgs.url = "github:Nixos/nixpkgs/nixpkgs-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+
+      # to work with older version of flakes
+      lastModifiedDate = self.lastModifiedDate or self.lastModified or "19700101";
+
+      # Generate a user-friendly version number.
+      version = builtins.substring 0 8 lastModifiedDate;
+
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+
+    in
+    {
+
+      # Provide some binary packages for selected system types.
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          zsd = pkgs.buildGoModule {
+            pname = "zsd";
+            inherit version;
+            # In 'nix develop', we don't need a copy of the source tree
+            # in the Nix store.
+            src = ./.;
+
+            #vendorSha256 = pkgs.lib.fakeSha256;
+            vendorSha256 = "sha256-9/E6yH6m4mioeuntA87jbgh6aMZfclJy3IAb/+P490Y=";
+          };
+        });
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.zsd}/bin/zsd";
+        };
+      });
+
+      formatter = forAllSystems (system: nixpkgsFor.${system}.nixpkgs-fmt);
+
+      devShells = forAllSystems (system: {
+        default = nixpkgsFor.${system}.mkShell {
+          packages = [
+            nixpkgsFor.${system}.go
+            self.packages.${system}.zsd
+          ];
+        };
+      });
+
+
+      defaultPackage = forAllSystems (system: self.packages.${system}.zsd);
+    };
+}


### PR DESCRIPTION
I added a very basic nix flake which can be used to source zsd from a nix flake nixos config as a package.  Also with nix flakes enabled you now are able to do `nix run github:j-keck/zsd`. Nothing you have to merge I just prefer using flakes to source nix packages and therefore packaged this as a flake for personal use.
The flake is very basic and is not able to replace default.nix for replacing default.nix a bit of extra work is needed.